### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Demo Model Context Protocol (MCP) server implemented in Python using the
 `http-mcp` package. It can run over HTTP (Starlette/Uvicorn) or over stdio,
 exposing example Tools and Prompts to any MCP-capable client.
 
+<a href="https://glama.ai/mcp/servers/@yeison-liscano/demo_http_mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yeison-liscano/demo_http_mcp/badge" alt="Demo HTTP Server MCP server" />
+</a>
+
 ### Requirements
 
 - Python 3.13


### PR DESCRIPTION
This PR adds a badge for the [Demo HTTP MCP Server](https://glama.ai/mcp/servers/@yeison-liscano/demo_http_mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@yeison-liscano/demo_http_mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yeison-liscano/demo_http_mcp/badge" alt="Demo HTTP Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.